### PR TITLE
Fix installation hangs when flashing with FlashFire.

### DIFF
--- a/scripts/inc.updatebinary.sh
+++ b/scripts/inc.updatebinary.sh
@@ -417,6 +417,8 @@ if [ "$g_conf" ]; then
   sed -i '/^$/d' $g_conf; # Remove all empty lines for cleaner appearance
 else
   config_file="Not Used";
+  g_conf=/tmp/proc_gconf;
+  touch "$g_conf";
 fi;
 
 # Unless this is a NoDebug install - create folder and take 'Before' snapshots


### PR DESCRIPTION
Thanks for this great project.
This PR fix installation hangs at [Line 573](https://github.com/opengapps/opengapps/blob/b320e48704e344f5f74f3cfeda6943807b158037/scripts/inc.updatebinary.sh#L573) when flashing with FlashFire and gapps-config not exists.
I have noticed only TWRP is supported in the FAQ, but there are several devices that custom recovery isn't available, unless unlock the bootloader (and unlocking may cause some feature stop working, such as Galaxy S6), so I hope an on-device flasher is also basically supported.